### PR TITLE
Make debug production dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
   ],
   "author": "Brian Dentino <brian.dentino@gmail.com>",
   "license": "MIT",
-  "devDependencies": {
-    "debug": "2.1.1"
+  "dependencies": {
+    "debug": ">=2.1.1"
   },
   "main": "./redebug.js"
 }


### PR DESCRIPTION
`debug` is actually normal dependency, not dev.
